### PR TITLE
Make jettison JDK 10+ compliant

### DIFF
--- a/src/main/java/org/codehaus/jettison/mapped/MappedNamespaceConvention.java
+++ b/src/main/java/org/codehaus/jettison/mapped/MappedNamespaceConvention.java
@@ -40,7 +40,7 @@ import org.codehaus.jettison.json.JSONObject;
 public class MappedNamespaceConvention implements Convention, NamespaceContext {
 	private static final String DOT_NAMESPACE_SEP = ".";
     private Map<Object, Object> xnsToJns = new HashMap<Object, Object>();
-    private Map<Object, Object> jnsToXns = new HashMap<Object, Object>();
+    private Map<String, Object> jnsToXns = new HashMap<String, Object>();
     private List<?> attributesAsElements;
     private List<?> ignoredElements;
     private List<String> jsonAttributesAsElements;
@@ -74,7 +74,7 @@ public class MappedNamespaceConvention implements Convention, NamespaceContext {
         this.jsonNamespaceSeparator = config.getJsonNamespaceSeparator();
         for (Iterator<Map.Entry<Object, Object>> itr = xnsToJns.entrySet().iterator(); itr.hasNext();) {
             Map.Entry<?, ?> entry = itr.next();
-            jnsToXns.put(entry.getValue(), entry.getKey());
+            jnsToXns.put((String)entry.getValue(), entry.getKey());
         }
         
         jsonAttributesAsElements = new ArrayList<String>();
@@ -191,10 +191,10 @@ public class MappedNamespaceConvention implements Convention, NamespaceContext {
         }
     }
 
-    public Iterator<Object> getPrefixes( String arg0 ) {
+    public Iterator<String> getPrefixes( String arg0 ) {
 
         if ( ignoreNamespaces ) {
-            return Collections.emptySet().iterator();
+            return Collections.<String>emptySet().iterator();
         }
         else {
             return jnsToXns.keySet().iterator();

--- a/src/test/java/org/codehaus/jettison/badgerfish/BadgerFishDOMTest.java
+++ b/src/test/java/org/codehaus/jettison/badgerfish/BadgerFishDOMTest.java
@@ -94,7 +94,7 @@ public class BadgerFishDOMTest extends DOMTest {
         String resStr = toJSON(parse(xmlStr));
         assertEquals("Unexpected result: " + resStr, expStr, resStr);
 
-        String resXML = toXML(resStr).replace(System.getProperty("line.separator"), "");
+        String resXML = toXML(resStr).replace(System.getProperty("line.separator"), "").replaceAll(">\\s+<", "><");
         assertEquals("Unexpected result: " + resXML, xmlStr, resXML);
     }
 	
@@ -104,7 +104,7 @@ public class BadgerFishDOMTest extends DOMTest {
         String resStr = toJSON(parse(xmlStr));
         assertEquals("Unexpected result: " + resStr, expStr, resStr);
 
-        String resXML = toXML(resStr).replace(System.getProperty("line.separator"), "");
+        String resXML = toXML(resStr).replace(System.getProperty("line.separator"), "").replaceAll(">\\s+<", "><");
         assertEquals("Unexpected result: " + resXML, xmlStr, resXML);
     }
 


### PR DESCRIPTION
 * Fixes https://github.com/jettison-json/jettison/issues/21 
 * Enhances BadgerFishDOMTest to ignore whitespaces in string comparison of xml
    *  => all tests pass now

I tried to build RESTEasy with 1.3.9-SNAPSHOT and it's passing, jettison TS passing too.