### PR TITLE
Avoid NullPointerException when used from some consumers

### DIFF
--- a/src/main/java/org/codehaus/jettison/mapped/MappedXMLStreamWriter.java
+++ b/src/main/java/org/codehaus/jettison/mapped/MappedXMLStreamWriter.java
@@ -243,6 +243,10 @@ public class MappedXMLStreamWriter extends AbstractXMLStreamWriter {
 	}
 	
 	public void writeStartElement(String prefix, String local, String ns) throws XMLStreamException {
+		if (current == null) {
+			this.writeStartDocument();
+		}
+
 		String parentKey = current.getTreeKey();
 		stack.push(current);
 		String key = convention.createKey(prefix, ns, local);


### PR DESCRIPTION
When used from some consumers (external components out of our control - in particular Axis2) there is no call to `writeStartDocument()` before the first `MappedXMLStreamWriter.writeStartElement()` which results in a NullPointerException.

This is solved by an implicit `writeStartDocument()` from `writeStartElement()` if required.