### PR TITLE
Use BigDecimal instead of Double to avoid loss of precision

### DIFF
--- a/src/main/java/org/codehaus/jettison/json/JSONTokener.java
+++ b/src/main/java/org/codehaus/jettison/json/JSONTokener.java
@@ -15,6 +15,8 @@ limitations under the License.
 */
 package org.codehaus.jettison.json;
 
+import java.math.BigDecimal;
+
 /**
  * A JSONTokener takes a source string and extracts characters and tokens from
  * it. It is used by the JSONObject and JSONArray constructors to parse
@@ -23,6 +25,11 @@ package org.codehaus.jettison.json;
  * @version 2
  */
 public class JSONTokener {
+
+    private static final String USE_BIGDECIMAL_JSONTOKENER_KEY = "jettison.json.jsontokener.use_bigdecimal";
+    public static final boolean USE_BIGDECIMAL_JSONTOKENER = Boolean.getBoolean( USE_BIGDECIMAL_JSONTOKENER_KEY );
+    protected boolean useBigDecimal = USE_BIGDECIMAL_JSONTOKENER; 
+
 
     /**
      * The index of the next character.
@@ -308,7 +315,8 @@ public class JSONTokener {
 
 
     /**
-     * Get the next value. The value can be a Boolean, Double, Integer,
+     * Get the next value. The value can be a Boolean, Double/BigDecimal
+     * (depending on -Djettison.json.jsontokener.use_bigdecimal), Integer,
      * JSONArray, JSONObject, Long, or String, or the JSONObject.NULL object.
      * @throws JSONException If syntax error.
      *
@@ -398,7 +406,11 @@ public class JSONTokener {
                     return Long.valueOf(s);
                 } catch (Exception f) {
                     try {
-                        return new Double(s);
+                        if (useBigDecimal) {
+                            return new BigDecimal(s);
+                        } else {
+                            return new Double(s);
+                        }
                     }  catch (Exception g) {
                         return s;
                     }

--- a/src/test/java/org/codehaus/jettison/json/JSONTokenerTest.java
+++ b/src/test/java/org/codehaus/jettison/json/JSONTokenerTest.java
@@ -1,0 +1,27 @@
+package org.codehaus.jettison.json;
+
+import java.math.BigDecimal;
+
+import junit.framework.TestCase;
+
+public class JSONTokenerTest extends TestCase {
+    
+    public void testDoublePrecision() throws Exception {
+        JSONTokener doubleTokener = new JSONTokener("9999999999999.9999");
+        Object nextValue = doubleTokener.nextValue();
+        assertEquals(Double.class, nextValue.getClass());
+        assertEquals(Double.valueOf("1.0E13"), nextValue);
+    }
+
+    public void testBigDecimalPrecision() throws Exception {
+        JSONTokener bigDecimalTokener = new JSONTokener("9999999999999.9999") {
+            {
+                this.useBigDecimal = true;
+            }
+        };
+        Object nextValue = bigDecimalTokener.nextValue();
+        assertEquals(BigDecimal.class, nextValue.getClass());
+        assertEquals(new BigDecimal("9999999999999.9999"), nextValue);
+    }
+
+}


### PR DESCRIPTION
In our use case, the loss of precision when parsing decimal numbers as floating point is not acceptable. This pull request proposes switching parsing from `Double` to `BigDecimal`. Because this is a behaviour change, it puts it behind the `jettison.json.jsontokener.use_bigdecimal` system property so that other consumers are unaffected unless they opt in.